### PR TITLE
Terse init function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test/test-dist.js

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   },
   "scripts": {
     "pretest": "browserify test/test.js -o test/test-dist.js",
-    "test": "firefox test/index.html"
+    "test": "open test/index.html"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "tap-parser": "^1.1.6"
   },
   "devDependencies": {
+    "browserify": "13.1.0",
     "tape": "^4.0.2",
     "tape-dom": "^0.0.4"
   },

--- a/src/dom_consumer.js
+++ b/src/dom_consumer.js
@@ -144,17 +144,26 @@ function add_some_dom (row) {
     }
 }
 
+function stream (tape) {
+    var stream = tape.createStream({ objectMode: true });
+    stream.on('data', add_some_dom);
+}
 
-module.exports = {
-    stream: function (tape) {
-        var stream = tape.createStream({ objectMode: true });
-        stream.on('data', add_some_dom);
-    },
-    installCSS: function () {
-        var link = document.createElement('style');
-        link.setAttribute("type", "text/css");
-        var css_body = document.createTextNode(tape_css);
-        link.appendChild(css_body);
-        document.head.appendChild(link);
-    }
-};
+function installCSS () {
+    var link = document.createElement('style');
+    link.setAttribute("type", "text/css");
+    var css_body = document.createTextNode(tape_css);
+    link.appendChild(css_body);
+    document.head.appendChild(link);
+}
+
+function init (tape) {
+    installCSS();
+    stream(tape);
+    return init;
+}
+
+init.installCSS = installCSS;
+init.stream = stream;
+
+module.exports = init;

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,8 @@ if (typeof(window)==='object') {
     var tape_dom = require('..');
     tape_dom.installCSS();
     tape_dom.stream(tape);
+    // This also works
+    // require('..')(tape)
 }
 
 


### PR DESCRIPTION
This allows a concise `require('tape-dom')(tape)` 1-liner setup.

This change is technically backward compatible (tests still pass unchanged). However, since we're exporting a function instead of just an object, releasing as semver major might be cautious. I'd suggest releasing as `1.0.0` to get out of semver zero major land anyway.
