### PR TITLE
Use diff-match-patch modules instead of googlediff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/test-dist.js
+node_modules

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "main": "src/dom_consumer.js",
   "browser": "src/dom_consumer.js",
   "dependencies": {
-      "googlediff": "^0.1.0",
-      "tap-parser": "^1.1.6"
+    "diff-match-patch": "^1.0.0",
+    "tap-parser": "^1.1.6"
   },
   "devDependencies": {
-    "browserify": "13.1.0",
+    "browserify": "13.1.0",    
     "tape": "^4.0.2",
     "tape-dom": "^0.0.4"
   },

--- a/src/dom_consumer.js
+++ b/src/dom_consumer.js
@@ -1,5 +1,5 @@
 "use strict";
-var DiffMatchPatch = require('googlediff');
+var DiffMatchPatch = require('diff-match-patch');
 var dmp = new DiffMatchPatch();
 //var tape = require('tape');
 var tape_css = require('./tape_css');


### PR DESCRIPTION
The **diff-match-patch** does the same as **googlediff** but solves the issue with **this** context. I was having troubles with this while using Browserify, this change fixes that.

More info [here](https://github.com/shimondoodkin/googlediff/pull/7) and [here](https://github.com/twada/power-assert-runtime/pull/13).

Thanks for the library!